### PR TITLE
Use tmp to store bootstrap/cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 composer.lock
+bootstrap/cache

--- a/app.yaml.example
+++ b/app.yaml.example
@@ -12,6 +12,9 @@ env_variables:
   APP_DEBUG: false
   SESSION_DRIVER: firestore
   CACHE_DRIVER: firestore
+  ## Store bootstrap cache files in writeable /tmp.
+  APP_SERVICES_CACHE: /tmp/bootstrap-cache-services.php
+  APP_PACKAGES_CACHE: /tmp/bootstrap-cache-packages.php
 
 handlers:
 - url: /robots.txt


### PR DESCRIPTION
Previously bootstrap/cache needed to be generated during the CI process as `bootstrap` folder was not writeable and the path was hardcoded. Now it can be generated directly inside App Engine.