### PR TITLE
MySQL IAM authentication

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -48,9 +48,10 @@ return [
             'url' => env('DATABASE_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
-            'password' => env('DB_PASSWORD', ''),
+            'database' => env('DB_DATABASE', env('GAE_SERVICE', 'forge')), // Use service name as default database.
+            // IAM authentication (ref.: https://cloud.google.com/sql/docs/mysql/iam-logins)
+            'username' => env('DB_USERNAME', env('GOOGLE_CLOUD_PROJECT', 'forge')),
+            'password' => env('DB_PASSWORD', app(\Google\Auth\Credentials\GCECredentials::class)->fetchAuthToken()['access_token']),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',

--- a/config/database.php
+++ b/config/database.php
@@ -51,7 +51,7 @@ return [
             'database' => env('DB_DATABASE', env('GAE_SERVICE', 'forge')), // Use service name as default database.
             // IAM authentication (ref.: https://cloud.google.com/sql/docs/mysql/iam-logins)
             'username' => env('DB_USERNAME', env('GOOGLE_CLOUD_PROJECT', 'forge')),
-            'password' => env('DB_PASSWORD', app(\Google\Auth\Credentials\GCECredentials::class)->fetchAuthToken()['access_token']),
+            'password' => env('DB_PASSWORD') ?? app(\Google\Auth\Credentials\GCECredentials::class)->fetchAuthToken()['access_token'],
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',


### PR DESCRIPTION
To setup MySQL IAM authentication (passwordless authentication):
1. Add `cloudsql_iam_authentication` flag to your MySQL instance (https://cloud.google.com/sql/docs/mysql/create-edit-iam-instances)
2. Add AppEngine service (`YOUR_PROJECT_ID@appspot.gserviceaccount.com`) as MySQL user, and grant `YOUR_PROJECT_ID ` user permissions to access database (https://cloud.google.com/sql/docs/mysql/add-manage-iam-users#creating-a-database-user).

Thats it!
