### PR TITLE
Install composer/composer on dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "spatie/laravel-google-cloud-storage": "^2.2"
     },
     "require-dev": {
+        "composer/composer": "^2.1",
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",


### PR DESCRIPTION
In order to run composer inside the dev instance pre-install `composer/composer`.

Example usage:
```
/cnb/lifecycle/launcher php vendor/bin/composer update
```